### PR TITLE
Fix support kubectl, subprocess and fix install helm

### DIFF
--- a/DependencyInsScripts/LinuxSetup.py
+++ b/DependencyInsScripts/LinuxSetup.py
@@ -54,8 +54,16 @@ class LinuxInstaller:
             subprocess.run(["curl", "-L", helm_url, "-o", tar_path], check=True)
             with tarfile.open(tar_path, "r:gz") as tar:
                 tar.extractall(path=tmpdirname)
-            shutil.move(os.path.join(tmpdirname, "linux-amd64/helm"), "/usr/local/bin/helm")
-        subprocess.run(["chmod", "+x", "/usr/local/bin/helm"], check=True)
+            #shutil.move(os.path.join(tmpdirname, "linux-amd64/helm"), "/usr/local/bin/helm")
+            
+            cmd_sudo = "sudo mv -v {} /usr/local/bin/helm".format(os.path.join(tmpdirname) + "/linux-amd64/helm")
+
+            subprocess.run(cmd_sudo, shell=True, check=True)
+
+        #subprocess.run(["chmod", "+x", "/usr/local/bin/helm"], check=True)
+
+        subprocess.run("sudo chmod +x /usr/local/bin/helm", shell=True, check=True)
+        
         print("Helm installation completed.")
 
     @staticmethod
@@ -68,12 +76,23 @@ class LinuxInstaller:
         print("Kind installation completed.")
 
     @staticmethod
+    def install_kubectl():
+        print("Installing Kubectl...")
+        VERSION_KCTL="v1.29.2"
+        kubectl_url = "https://dl.k8s.io/release/{}/bin/linux/amd64/kubectl".format(VERSION_KCTL)
+        subprocess.run(f"curl -Lo ./kubectl {kubectl_url}", shell=True, check=True)
+        subprocess.run("chmod +x ./kubectl", shell=True, check=True)
+        subprocess.run("sudo mv ./kubectl /usr/local/bin/kubectl", shell=True, check=True)
+        print("Kubectl installation completed.")
+
+    @staticmethod
     def main():
         required_utilities = ["curl"]
         LinuxInstaller.install_missing_utilities(required_utilities)
         LinuxInstaller.install_docker()
         LinuxInstaller.install_helm()
         LinuxInstaller.install_kind()
+        LinuxInstaller.install_kubectl()
 
 if __name__ == "__main__":
     LinuxInstaller.main()

--- a/LabManager.py
+++ b/LabManager.py
@@ -1,3 +1,6 @@
+#import dependencies
+import subprocess
+
 class LabManager:
     def __init__(self, kind_helm_manager, config_manager):
         self.kind_helm_manager = kind_helm_manager


### PR DESCRIPTION
Hi, 

I apport some code for the laboratory on-premise.

helm:

```
Installing Helm...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15.3M  100 15.3M    0     0  26.7M      0 --:--:-- --:--:-- --:--:-- 26.7M
Traceback (most recent call last):
  File "/usr/lib/python3.10/shutil.py", line 816, in move
    os.rename(src, real_dst)
PermissionError: [Errno 13] Permission denied: '/tmp/tmpbej2qo_z/linux-amd64/helm' -> '/usr/local/bin/helm'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/kcdctl/kcdctl.py", line 69, in <module>
    main()    
  File "/home/ubuntu/kcdctl/kcdctl.py", line 29, in main
    detOSandInsDep()  # Setup environment based on the detected OS
  File "/home/ubuntu/kcdctl/kcdctl.py", line 20, in detOSandInsDep
    LinuxInstaller.main()
  File "/home/ubuntu/kcdctl/DependencyInsScripts/LinuxSetup.py", line 75, in main
    LinuxInstaller.install_helm()
  File "/home/ubuntu/kcdctl/DependencyInsScripts/LinuxSetup.py", line 57, in install_helm
    shutil.move(os.path.join(tmpdirname, "linux-amd64/helm"), "/usr/local/bin/helm")
  File "/usr/lib/python3.10/shutil.py", line 836, in move
    copy_function(src, real_dst)
  File "/usr/lib/python3.10/shutil.py", line 434, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.10/shutil.py", line 256, in copyfile
    with open(dst, 'wb') as fdst:
PermissionError: [Errno 13] Permission denied: '/usr/local/bin/helm'

```
subprocess:

```
Successfully deployed Helm chart: ./Labs/Service Misconfiguration - Lab 2/lab2-helm as release: lab2
Traceback (most recent call last):
  File "/home/ubuntu/kcdctl/LabManager.py", line 40, in set_kube_context
    subprocess.run(context_command, shell=True, check=True)
NameError: name 'subprocess' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/kcdctl/kcdctl.py", line 69, in <module>
    main()    
  File "/home/ubuntu/kcdctl/kcdctl.py", line 49, in main
    lab_manager.deploy_lab(lab_id)
  File "/home/ubuntu/kcdctl/LabManager.py", line 29, in deploy_lab
    self.set_kube_context(lab_config["cluster_name"])
  File "/home/ubuntu/kcdctl/LabManager.py", line 43, in set_kube_context
    except subprocess.CalledProcessError as e:
NameError: name 'subprocess' is not defined

```

kubectl:

```
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
Successfully deployed Helm chart: ./Labs/Service Misconfiguration - Lab 2/lab2-helm as release: lab2
/bin/sh: 1: kubectl: not found
Failed to set Kubernetes context: Command 'kubectl config use-context kind-lab2-cluster' returned non-zero exit status 127.
Enter command: delete lab2

```

regards.